### PR TITLE
query.js now deals with new funny list types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ typings/
 # dotenv environment variables file
 .env
 
+.idea

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # loopback-connector-gdatastore
-Google DataStore connector for loopback
+Google Cloud Platform DataStore connector for loopback
+
+###Disclaimer:
+This is a forked version of loopback-connector-gdatastore
 
 ## Installation
 
-    npm install loopback-connector-gdatastore --save
+    npm install loopback-connector-gcp-datastore --save
 
 ## Setup datasources.json
 ```json
   "gdatastore": {
     "name": "gdatastore",
-    "connector": "loopback-connector-gdatastore",
+    "connector": "loopback-connector-gcp-datastore",
     "projectId": "gcloud-project-id",
     "namespace": "datastore-namespace"
   }

--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -43,7 +43,6 @@ GDataStore.prototype.callback = function (errors, result, callback) {
     if (errors) {
         return callback(errors);
     }
-    // Done
     callback(null, result);
 };
 
@@ -99,7 +98,7 @@ GDataStore.prototype.updateAttributes = function (model, id, data, options, call
             this.callback(errors, result, callback);
         });
     });
-}
+};
 
 GDataStore.prototype.replaceById = function (model, id, data, options, callback, v) {
     debug('replaceById: %s %s %s %s', model, id, JSON.stringify(data),
@@ -122,4 +121,4 @@ GDataStore.prototype.destroyAll = function (model, filter, options, callback) {
             this.callback(errors, result, callback);
         });
     });
-}
+};

--- a/lib/query.js
+++ b/lib/query.js
@@ -1,4 +1,4 @@
-var debug = require('debug')('loopback:connector:gdatastore');
+let debug = require('debug')('loopback:connector:gdatastore');
 const Datastore = require('@google-cloud/datastore');
 const _ = require('./util');
 
@@ -48,7 +48,7 @@ Query.prototype.where = function (data, name) {
     } else {
         debug('find: adding filter %s = %s', name, JSON.stringify(data));
 
-        var op = '=';
+        let op = '=';
         if (data instanceof Object) {
             if (Object.keys(data).length === 1) {
                 if (data.gt) {
@@ -111,8 +111,8 @@ Query.prototype.findById = function (id, callback) {
 };
 
 Query.prototype.create = function (data, callback) {
-    var id = data[this.idName];
-    var key;
+    let id = data[this.idName];
+    let key;
     if (id) {
         debug('create: using preset: %s %s', this.idName, id);
         key = this.ds.key([this.model, id]);
@@ -129,7 +129,7 @@ Query.prototype.create = function (data, callback) {
             return callback(errors);
         }
         if (!key.path && !key.path[1]) {
-            var err = new Error('Datastore error: missing key.path');
+            let err = new Error('Datastore error: missing key.path');
             return callback(err);
         }
         callback(null, key.path[1]);
@@ -158,7 +158,7 @@ Query.prototype.update = function (id, data, callback) {
             callback(null, id);
         });
     });
-}
+};
 
 Query.prototype.deleteById = function (id, callback) {
     let key = this.ds.key([this.model, id]);
@@ -168,17 +168,17 @@ Query.prototype.deleteById = function (id, callback) {
         }
         callback(null, id);
     });
-}
+};
 
 // Convert to a proper DB format, with indexes off as needed
 Query.prototype.toDatastoreFormat = function (data) {
     // removes __key__ from collection
     delete data[this.idName];
 
-    var properties = this.definition.properties;
+    let properties = this.definition.properties;
     return _.map(data, (value, name) => {
-        var excluded;
-        var property = properties[name];
+        let excluded;
+        let property = properties[name];
         if (!property) {
             excluded = true;
             if (this.definition.settings.strict) {
@@ -199,13 +199,13 @@ Query.prototype.toDatastoreFormat = function (data) {
 };
 
 Query.prototype.mapRelations = function (property, callback) {
-    var relations = this.definition.settings.relations;
+    let relations = this.definition.settings.relations;
     if (relations) {
         _.forin(relations, (val) => {
             if (val.foreignKey === property &&
-                val.type == 'belongsTo') {
+                val.type === 'belongsTo') {
                 callback(val);
             }
         });
     }
-}
+};

--- a/lib/query.js
+++ b/lib/query.js
@@ -99,7 +99,7 @@ Query.prototype.select = function (callback) {
 
 Query.prototype.findById = function (id, callback) {
     let filter = { where: {}, limit: 1 };
-    filter.where[this.idName] = id;
+    filter.where[this.idName] = parseInt(id);
     this.filter(filter);
     this.select((errors, result) => {
         if (errors) {
@@ -147,7 +147,7 @@ Query.prototype.update = function (id, data, callback) {
             }
         });
         _data = this.toDatastoreFormat(_data);
-        let key = this.ds.key([this.model, id]);
+        let key = this.ds.key([this.model, parseInt(id)]);
         this.ds.update({
             key: key,
             data: _data
@@ -161,7 +161,7 @@ Query.prototype.update = function (id, data, callback) {
 };
 
 Query.prototype.deleteById = function (id, callback) {
-    let key = this.ds.key([this.model, id]);
+    let key = this.ds.key([this.model, parseInt(id)]);
     this.ds.delete(key, (errors, result) => {
         if (errors) {
             return callback(errors);

--- a/lib/query.js
+++ b/lib/query.js
@@ -37,7 +37,15 @@ Query.prototype.where = function (data, name) {
     // How to handle?
     if (this.idName == name) {
         debug('find: adding filter by __key__ = %s', data);
-        let key = this.ds.key([this.model, data]);
+
+        parsedId = parseInt(data);
+        let key;
+        if (isNaN(parsedId)) {
+            key = this.ds.key([this.model, data]);
+        } else {
+            key = this.ds.key([this.model, parsedId]);
+        }
+
         this.query.filter('__key__', '=', key);
     } else if ('and' === name) {
         _.forin(data, (val, key) => {

--- a/lib/query.js
+++ b/lib/query.js
@@ -49,13 +49,26 @@ Query.prototype.where = function (data, name) {
         debug('find: adding filter %s = %s', name, JSON.stringify(data));
 
         var op = '=';
-        if (data instanceof Object && Object.keys(data).length === 1)
-        {
-            if (data.gt) op = '>';
-            if (data.gte) op = '>=';
-            if (data.lt) op = '<';
-            if (data.lte) op = '<=';
-            if (op !== '=') data = data[Object.keys(data)[0]];
+        if (data instanceof Object) {
+            if (Object.keys(data).length === 1) {
+                if (data.gt) {
+                    op = '>';
+                } else if (data.gte) {
+                    op = '>=';
+                } else if (data.lt) {
+                    op = '<';
+                } else if (data.lte) {
+                    op = '<=';
+                } else {
+                    debug('find: IGNORING LIST TYPE %s', name);
+                    return;
+                }
+
+                if (op !== '=') data = data[Object.keys(data)[0]];
+            } else {
+                debug('find: IGNORING LIST TYPE %s', name);
+                return;
+            }
         }
 
         this.mapRelations(name, (relation) => {
@@ -67,7 +80,7 @@ Query.prototype.where = function (data, name) {
 
 Query.prototype.select = function (callback) {
     this.ds.runQuery(this.query, (error, result, cursor) => {
-        if (result.length > 0) {
+        if (result !== undefined && result.length > 0) {
             result = result.map((entity) => {
                 let key = entity[Datastore.KEY];
                 entity[this.idName] = key[this.idName];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-connector-gcp-datastore",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Google Cloud Platform DataStore connector for loopback",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-connector-gcp-datastore",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Google Cloud Platform DataStore connector for loopback",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "loopback-connector-gdatastore",
-  "version": "1.0.6",
-  "description": "Google DataStore connector for loopback",
+  "name": "loopback-connector-gcp-datastore",
+  "version": "1.0.7",
+  "description": "Google Cloud Platform DataStore connector for loopback",
   "main": "index.js",
   "scripts": {
     "test": "mocha test --timeout 9999 -R spec"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/impesa/loopback-connector-gdatastore.git"
+    "url": "git+https://github.com/ScaleneZA/loopback-connector-gdatastore.git"
   },
   "keywords": [
     "Loopback",
@@ -21,9 +21,9 @@
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/impesa/loopback-connector-gdatastore/issues"
+    "url": "https://github.com/ScaleneZA/loopback-connector-gdatastore/issues"
   },
-  "homepage": "https://github.com/impesa/loopback-connector-gdatastore#readme",
+  "homepage": "https://github.com/ScaleneZA/loopback-connector-gdatastore#readme",
   "dependencies": {
     "@google-cloud/datastore": "^1.1.0",
     "lodash.forin": "^4.4.0",


### PR DESCRIPTION
When I was using this package on my loopback application, I was getting a lot of weird errors, due to Loopback trying to give Gcloud Datastore list types where they shouldn't be, but I've changed it to ignore these list types, it seems to work correctly.